### PR TITLE
Changes submitted for Mx 8.18.12

### DIFF
--- a/javasource/scheduler/impl/MxSchedulerListener.java
+++ b/javasource/scheduler/impl/MxSchedulerListener.java
@@ -10,6 +10,8 @@ import org.quartz.TriggerListener;
 
 import com.mendix.core.Core;
 import com.mendix.logging.ILogNode;
+// PBornier Update
+import com.mendix.systemwideinterfaces.core.IMendixIdentifier;
 import com.mendix.systemwideinterfaces.core.IMendixObject;
 
 public class MxSchedulerListener implements JobListener, TriggerListener {
@@ -84,6 +86,8 @@ public class MxSchedulerListener implements JobListener, TriggerListener {
 	protected void evalMonitorInfo( JobExecutionContext jobContext ) {
 		JobDataMap dataMap = jobContext.getJobDetail().getJobDataMap();
 		IMendixObject monitor = (IMendixObject) dataMap.get(ScheduledJob.Monitor);
+		// PBornier Update
+		IMendixIdentifier instance = (IMendixIdentifier) dataMap.get(ScheduledJob.InstanceId);
 
 		ScheduleManager.updateMonitorInformation(monitor, jobContext.getPreviousFireTime(), jobContext.getScheduledFireTime(),
 				jobContext.getFireTime(), jobContext.getNextFireTime(), jobContext.getTrigger());

--- a/javasource/scheduler/impl/ScheduleManager.java
+++ b/javasource/scheduler/impl/ScheduleManager.java
@@ -290,7 +290,8 @@ public class ScheduleManager {
 
 		return false;
 	}
-
+	
+	// PBornier Update
 	protected Trigger setupActionTrigger( ActionConfig config, IMendixObject monitor ) throws ParseException, CoreException {
 		String expression = getCronExpression(config);
 


### PR DESCRIPTION
Just removing the empty object related to the Monitor entity in 3 places.
The same fix is existing in the next release of the Scheduler (v.1.6) but not present in the release 1.5.